### PR TITLE
Fixing prop methods not being used in getCommandMock

### DIFF
--- a/src/FPhactoryCommandTest.php
+++ b/src/FPhactoryCommandTest.php
@@ -36,7 +36,7 @@ class FPhactoryCommandTest extends FPhactoryTestCase
 
         $mock = $this->getMockBuilder($className)
             ->setConstructorArgs([$name, $runner])
-            ->setMethods(['prompt'])
+            ->setMethods(array_merge(['prompt'], $methods))
             ->getMock()
         ;
         return $mock;

--- a/src/FPhactoryTestCase.php
+++ b/src/FPhactoryTestCase.php
@@ -2,6 +2,7 @@
 namespace fidelize\YiiPhactory;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 abstract class FPhactoryTestCase extends TestCase
 {
@@ -33,5 +34,32 @@ abstract class FPhactoryTestCase extends TestCase
     {
         parent::tearDown();
         $this->_transaction->rollBack();
+    }
+    
+    /**
+     * @param object $classObject
+     * @param string $property
+     * This method is used to get private AND protected class property values
+     */
+    protected function getPrivatePropertyValue($classObject, $property)
+    {
+        $reflection = new ReflectionClass($classObject);
+        $reflection_property = $reflection->getProperty($property);
+        $reflection_property->setAccessible(true);
+        return $reflection_property->getValue($classObject);
+    }
+    
+    /**
+     * @param object $classObject
+     * @param string $methodName
+     * @param array $args
+     * This method is used to execute private AND protected methods
+     */
+    protected function executePrivateMethod($classObject, $methodName, $args)
+    {
+        $reflection = new ReflectionClass($classObject);
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+        return $method->invokeArgs($classObject, $args);
     }
 }


### PR DESCRIPTION
Added array_merge in the mock "setMethods" to getCommandMock be able to have custom mocked methods.